### PR TITLE
Start of SharePoint helpers (splitSPUser,splitDisplayNames)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,17 @@ gulp test - TODO
 gulp serve - TODO
 gulp bundle - TODO
 gulp package-solution - TODO
+
+
+### SharePoint Helpers
+
+Available SharePoint Helpers are
+* splitDisplayNames (input => "user1;user2;user3") (common example is the author field)
+* splitSPUser (input => "email | displayname | .... i:0#.f|membership|username") (common example is the editor field)
+
+They can be use in the template as follows:
+```bash
+{{splitDisplayNames Author}}
+{{splitSPUser EditorOWSUSER 'displayName'}}
+
+```

--- a/src/webparts/searchVisualizer/components/SearchVisualizer.tsx
+++ b/src/webparts/searchVisualizer/components/SearchVisualizer.tsx
@@ -12,6 +12,13 @@ import { Spinner, SpinnerSize, MessageBar, MessageBarType, Dialog, DialogType } 
 import { ISearchResponse } from "../services/ISearchService";
 import * as strings from 'searchVisualizerStrings';
 
+
+export interface SPUser {
+    username?: string;
+    displayName?: string;
+    email?: string;
+}
+
 export default class SearchVisualizer extends React.Component<ISearchVisualizerProps, ISearchVisualizerState> {
     private _searchService: SearchService;
     private _results: any[] = [];
@@ -45,6 +52,36 @@ export default class SearchVisualizer extends React.Component<ISearchVisualizerP
 
         // Load the typeof field handler for debugging
         Handlebars.registerHelper('typeof', TypeofHelper);
+
+
+        // SharePoint helper to split SPUserField (?multiple) into a string
+        // The template provide the property which will be returned
+        Handlebars.registerHelper('splitSPUser', function (userFieldValue, propertyRequested) {
+
+            if (userFieldValue == null)
+                return null;
+
+            const retValue:string[]=[];
+            let userFieldValueArray = userFieldValue.split(';').forEach(user => {
+                let userValues = user.split(' | ');
+                let spuser: SPUser = {
+                    displayName: userValues[1],
+                    email: userValues[0]
+                }
+                retValue.push(spuser[propertyRequested]);
+            });
+
+            return retValue.join(', ');
+        });
+
+        // SHarePoint helper to split the displaynames of for example the Author field (user1;user2...)
+        Handlebars.registerHelper('splitDisplayNames', function (displayNames) {
+
+            if (displayNames == null && displayNames.indexOf(';') == -1)
+                return null;
+
+            return displayNames.split(';').join(", ");;
+        });
     }
 
     /**

--- a/templates/test.html
+++ b/templates/test.html
@@ -1,6 +1,6 @@
 <content id="metadata" type="x-handlebars-metadata">
     {
-        "fields": ["Path", "LastModifiedTime", "Title"],
+        "fields": ["Path", "LastModifiedTime", "Title","EditorOWSUSER","Author"],
         "query": "",
         "sort": ""
     }
@@ -18,14 +18,17 @@
         $(function() {
             $('.myRow').css('background-color', '#c00000');
         });
+		
     </script>
-
+	
     <div class="ms-Grid-row ms-bgColor-blueDark ms-fontColor-white myRow">
         <h1 class="ms-font-xl ms-fontColor-white">Web part title: {{wpTitle}}</h1>
 
         <ul>
             {{#each items}}
-                <li><a href="{{Path}}" class="ms-fontColor-white">{{Title}}</a> {{#if LastModifiedTime}} - Last time modified: {{moment LastModifiedTime "DD/MM/YYYY"}} {{/if}}</li>
+			
+                <li><a href="{{Path}}" class="ms-fontColor-white">{{Title}}</a> Created by Author => {{splitDisplayNames Author}}  {{#if LastModifiedTime}} - 
+                and last modified by {{splitSPUser EditorOWSUSER 'displayName'}} ({{moment LastModifiedTime "DD/MM/YYYY"}}) {{/if}}</li>
             {{/each}}
         </ul>
     </div>


### PR DESCRIPTION
### SharePoint Helpers

Available SharePoint helpers are
* splitDisplayNames (input => "user1;user2;user3") (common example is the author field)
* splitSPUser (input => "email | displayname | .... i:0#.f|membership|username") (common example is the editor field)

They can be used in the template as follows:
```bash
{{splitDisplayNames Author}}
{{splitSPUser EditorOWSUSER 'displayName'}}

```